### PR TITLE
Fix KeyError in Connection._handle_info_res

### DIFF
--- a/src/libopensonic/connection.py
+++ b/src/libopensonic/connection.py
@@ -2267,7 +2267,7 @@ class Connection(ConnBase[Response]):
         res.raise_for_status()
         dres = res.json()["subsonic-response"]
         self._check_status(dres)
-        return dres['subsonic-response']
+        return dres
 
 
     def _handle_bin_res(self, res: Response) -> Response:


### PR DESCRIPTION
Fix a recently introduced bug that causes `KeyError: 'subsonic-response'` on some requests.