### PR TITLE
Fix start_scan() and get_scan_status()

### DIFF
--- a/src/libopensonic/_async/connection.py
+++ b/src/libopensonic/_async/connection.py
@@ -1401,7 +1401,7 @@ class AsyncConnection:
         res = await self._do_request(method)
         dres = await self._handle_info_res(res)
         self._check_status(dres)
-        return ScanStatus.from_dict(dres['scanstatus'])
+        return ScanStatus.from_dict(dres['scanStatus'])
 
 
     async def get_shares(self) -> list[Share]:
@@ -2057,7 +2057,7 @@ class AsyncConnection:
         res = await self._do_request(method)
         dres = await self._handle_info_res(res)
         self._check_status(dres)
-        return ScanStatus.from_dict(dres['scanstatus'])
+        return ScanStatus.from_dict(dres['scanStatus'])
 
 
     async def stream(self, sid:str, max_bit_rate:int=0, tformat:str|None=None,

--- a/src/libopensonic/_sync/connection.py
+++ b/src/libopensonic/_sync/connection.py
@@ -1401,7 +1401,7 @@ class Connection:
         res = self._do_request(method)
         dres = self._handle_info_res(res)
         self._check_status(dres)
-        return ScanStatus.from_dict(dres['scanstatus'])
+        return ScanStatus.from_dict(dres['scanStatus'])
 
 
     def get_shares(self) -> list[Share]:
@@ -2057,7 +2057,7 @@ class Connection:
         res = self._do_request(method)
         dres = self._handle_info_res(res)
         self._check_status(dres)
-        return ScanStatus.from_dict(dres['scanstatus'])
+        return ScanStatus.from_dict(dres['scanStatus'])
 
 
     def stream(self, sid:str, max_bit_rate:int=0, tformat:str|None=None,

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1446,7 +1446,7 @@ class TestScanExtensions:
     async def test_get_scan_status(self, conn, mock_session, mock_response):
         """Test get_scan_status."""
         status = {
-            "scanstatus": {
+            "scanStatus": {
                 "scanning": False,
                 "count": 1000
             }
@@ -1457,12 +1457,13 @@ class TestScanExtensions:
         result = await conn.get_scan_status()
         assert isinstance(result, ScanStatus)
         assert result.scanning is False
+        assert result.count == 1000
 
     @pytest.mark.asyncio
     async def test_start_scan(self, conn, mock_session, mock_response):
         """Test start_scan."""
         status = {
-            "scanstatus": {
+            "scanStatus": {
                 "scanning": True,
                 "count": 0
             }
@@ -1473,6 +1474,7 @@ class TestScanExtensions:
         result = await conn.start_scan()
         assert isinstance(result, ScanStatus)
         assert result.scanning is True
+        assert result.count == 0
 
     @pytest.mark.asyncio
     async def test_get_open_subsonic_extensions(self, conn, mock_session, mock_response):


### PR DESCRIPTION
The `startScan` and `getScanStatus` endpoints return a subsonic-response with a nested scanStatus element on success.

https://opensubsonic.netlify.app/docs/endpoints/startscan/
https://opensubsonic.netlify.app/docs/endpoints/getscanstatus/

Whilst testing calling `startScan` on my LMS server I encountered the following error:

```
Traceback (most recent call last):
  File "/home/atj/dev/opensubsonic/test.py", line 47, in <module>
    conn.start_scan()
    ~~~~~~~~~~~~~~~^^
  File "/home/atj/dev/venv/lib/python3.13/site-packages/libopensonic/_sync/connection.py", line 2064, in start_scan
    return ScanStatus.from_dict(dres['scanstatus'])
                                ~~~~^^^^^^^^^^^^^^
KeyError: 'scanstatus'
```

Further investigation showed that the response contained a `scanStatus` element but the code was checking for `scanstatus`. Here's an example response from LMS:

```
<Response [200]>
{'openSubsonic': True,
 'scanStatus': {'scanning': False},
 'serverVersion': 'v3.76.0',
 'status': 'ok',
 'type': 'lms',
 'version': '1.16.1'}
```