### PR TITLE
Add music folder support to get_album_list2

### DIFF
--- a/src/libopensonic/_async/connection.py
+++ b/src/libopensonic/_async/connection.py
@@ -823,7 +823,8 @@ class AsyncConnection:
 
     async def get_album_list2(self, ltype:str, size:int=10, offset:int=0,
                       from_year:int|None=None, to_year:int|None=None,
-                      genre:str|None=None) -> list[AlbumID3]:
+                      genre:str|None=None,
+                      music_folder_id:int|None=None) -> list[AlbumID3]:
         """Return a list of albums filtered by type, organized using ID3 tags.
 
         Similar to get_album_list but uses ID3 tags for organization.
@@ -840,6 +841,8 @@ class AsyncConnection:
             from_year: Required when ltype is "byYear". Start of year range.
             to_year: Required when ltype is "byYear". End of year range.
             genre: Required when ltype is "byGenre". The genre name, e.g. "Rock".
+            music_folder_id: Only return albums in this music folder.
+                See get_music_folders().
 
         Returns:
             A list of media.AlbumID3 objects.
@@ -851,7 +854,7 @@ class AsyncConnection:
 
         q = self._get_query_dict({'type': ltype, 'size': size,
             'offset': offset, 'fromYear': from_year, 'toYear': to_year,
-            'genre': genre})
+            'genre': genre, 'musicFolderId': music_folder_id})
 
         res = await self._do_request(method, q)
         dres = await self._handle_info_res(res)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1003,6 +1003,28 @@ class TestAlbumSongLists:
         assert isinstance(result[0], AlbumID3)
 
     @pytest.mark.asyncio
+    async def test_get_album_list2_with_music_folder(
+        self, conn, mock_session, mock_response
+    ):
+        """Test get_album_list2 with a music folder filter."""
+        albums = {
+            "albumList2": {
+                "album": [
+                    {"id": "alb-1", "name": "Album 1", "songCount": 5,
+                     "duration": 1800, "created": "2024-01-01T00:00:00"}
+                ]
+            }
+        }
+        set_json_response(mock_response, make_response(albums))
+        mock_session.post = AsyncMock(return_value=mock_response)
+
+        result = await conn.get_album_list2("frequent", music_folder_id=1)
+        assert len(result) == 1
+        assert isinstance(result[0], AlbumID3)
+        data = mock_session.post.call_args.kwargs["data"]
+        assert data["musicFolderId"] == "1"
+
+    @pytest.mark.asyncio
     async def test_get_random_songs_empty(self, conn, mock_session, mock_response):
         """Test get_random_songs with empty result."""
         set_json_response(mock_response, make_response({"randomSongs": {}}))


### PR DESCRIPTION
This pull adds the music_folder_id to  get_album_list2 to align with get_album_list, this allows the user to scope requests to a specific library in multi-library system. 